### PR TITLE
feat(#55): score + grade on end screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ load time, splitting on `## ` version headings.
 - Balance: laser DPS 40 → 25 (felt OP in playtest).
 - Balance: radar detectRange 180 → 130 (a single radar no longer
   covers the entire playable map; meaningful but partial coverage).
+- End screen: numeric SCORE and letter GRADE (S/A/B/C/D/F) now
+  surfaced alongside the existing stats so a run feels graded, not
+  just won/lost. Score weights and grade thresholds live in
+  config.js → scoring (#55).
 
 ## v0.1.1 — 2026-04-26
 - Sim harness: live sidebar event log during a run; batch mode runs 10

--- a/src/config.js
+++ b/src/config.js
@@ -254,6 +254,30 @@ export const CONFIG = {
     autoCollapseMs: 8000,
   },
 
+  scoring: {
+    // End-of-run score (#55). Composite from existing stats; surfaced on the
+    // end screen as both a number and a letter grade. Tune freely — gradeThresholds
+    // is a descending list of [minScore, letter] pairs.
+    weights: {
+      wavesCleared:    1000,
+      structuresAlive:  500,
+      bridgesAlive:     100,
+      casualties:        -1,
+      structuresLost: -1500,
+      financialPenalty:  -1,
+    },
+    perfectRunBonus: 5000,   // 0 casualties + 0 structures lost + all bridges alive
+    gradeThresholds: [
+      [15000, 'S'],
+      [11000, 'A'],
+      [ 8000, 'B'],
+      [ 4000, 'C'],
+      [ 1000, 'D'],
+      [-Infinity, 'F'],
+    ],
+    gradeColors: { S: 'successGreen', A: 'successGreen', B: 'alertAmber', C: 'alertAmber', D: 'threatRed', F: 'threatRed' },
+  },
+
   endScreens: {
     // Perfect — no civilian losses, no structures lost, all bridges intact.
     winPerfect: {

--- a/src/ui/endScreen.js
+++ b/src/ui/endScreen.js
@@ -6,9 +6,11 @@ import { liveBridgeCount, totalBridgeCount } from '../game/state.js';
 const TEXT_COL_X = 60;
 const TEXT_COL_W = 360;
 const HEADLINE_Y = 36;
-const BODY_TOP_Y = 80;
-const BODY_BOTTOM_Y = 190;
+const BODY_TOP_Y = 70;
+const BODY_BOTTOM_Y = 158;
 const LINE_HEIGHT = 11;
+const SCORE_GRADE_Y = 165;       // top of big grade letter / score number
+const SCORE_LABEL_Y = 192;       // small "GRADE" / "SCORE" labels under each
 const PROMPT_Y = 252;
 
 const images = {};
@@ -124,9 +126,69 @@ export function renderEndScreen(ctx, state, tMs) {
   drawBackdrop(ctx, key);
   drawHeadline(ctx, entry, tMs, modeTag);
   drawBody(ctx, entry);
+  drawScoreGrade(ctx, state);
   drawCasualties(ctx, state);
   drawPrompt(ctx, tMs);
   ctx.restore();
+}
+
+export function computeScore(state) {
+  const w = CONFIG.scoring.weights;
+  const wavesCleared = state.winFlag ? 5 : Math.max(0, (state.wave?.number ?? 1) - 1);
+  let structuresAlive = 0;
+  for (const id of Object.keys(state.structureHp ?? {})) {
+    if ((state.structureHp[id] ?? 0) > 0) structuresAlive += 1;
+  }
+  const bridgesAlive = liveBridgeCount(state);
+  const casualties = totalCasualties(state);
+  const structuresLost = state.stats?.structuresLost ?? 0;
+  const financialPenalty = state.financialPenalty ?? 0;
+
+  let score =
+      wavesCleared    * w.wavesCleared
+    + structuresAlive * w.structuresAlive
+    + bridgesAlive    * w.bridgesAlive
+    + casualties      * w.casualties
+    + structuresLost  * w.structuresLost
+    + financialPenalty* w.financialPenalty;
+
+  if (casualties === 0 && structuresLost === 0 && bridgesAlive === totalBridgeCount()) {
+    score += CONFIG.scoring.perfectRunBonus;
+  }
+
+  let grade = 'F';
+  for (const [min, letter] of CONFIG.scoring.gradeThresholds) {
+    if (score >= min) { grade = letter; break; }
+  }
+  const color = CONFIG.colors[CONFIG.scoring.gradeColors[grade]] ?? CONFIG.colors.accentWhite;
+  return { score, grade, color };
+}
+
+function drawScoreGrade(ctx, state) {
+  const { score, grade, color } = computeScore(state);
+  const cx = CONFIG.virtualWidth / 2;
+
+  ctx.textBaseline = 'top';
+
+  // Big GRADE letter, left of center, color-coded.
+  ctx.font = '24px "Press Start 2P", monospace';
+  ctx.textAlign = 'right';
+  ctx.fillStyle = color;
+  ctx.fillText(grade, cx - 24, SCORE_GRADE_Y);
+
+  ctx.font = '6px "Press Start 2P", monospace';
+  ctx.fillStyle = CONFIG.colors.gridLine;
+  ctx.fillText('GRADE', cx - 24, SCORE_LABEL_Y);
+
+  // SCORE number, right of center.
+  ctx.font = '16px "Press Start 2P", monospace';
+  ctx.textAlign = 'left';
+  ctx.fillStyle = CONFIG.colors.accentWhite;
+  ctx.fillText(String(score), cx + 24, SCORE_GRADE_Y + 4);
+
+  ctx.font = '6px "Press Start 2P", monospace';
+  ctx.fillStyle = CONFIG.colors.gridLine;
+  ctx.fillText('SCORE', cx + 24, SCORE_LABEL_Y);
 }
 
 function formatRunTime(ms) {


### PR DESCRIPTION
First slice of #55. Score + grade on the end screen. Per-wave debrief intentionally deferred to a follow-up — keeps this PR small and lets you feel-test the grading curve before sinking time into per-wave UI.

## What
- New `CONFIG.scoring` block: weights for each component, perfect-run bonus, grade-threshold ladder, and per-grade colors.
- `computeScore(state)` exported from `endScreen.js` (also handy for sim-harness use later under #51).
- New `drawScoreGrade` panel between body and existing stats: 24px color-coded letter on the left, 16px score number on the right, tiny labels under each.
- Body band shrunk from y=80–190 to 70–158 to make vertical room for the grade letter without colliding with stats.

## Score formula (default weights)
- waves_cleared × 1000
- structures_alive × 500
- bridges_alive × 100
- casualties × −1
- structures_lost × −1500
- financial_penalty × −1
- +5000 perfect-run bonus (0 casualties, 0 structures lost, all bridges alive)

## Grade thresholds (default)
| Grade | Score    | Color |
|-------|----------|-------|
| S     | 15000+   | green |
| A     | 11000+   | green |
| B     |  8000+   | amber |
| C     |  4000+   | amber |
| D     |  1000+   | red   |
| F     | < 1000   | red   |

All numbers tune-able from `config.js` without touching the rendering path.

## Test plan
- [ ] Win a run cleanly → grade A or S, big green letter
- [ ] Win pyrrhic (heavy losses) → C or B, amber
- [ ] Lose mid-game → D or F, red
- [ ] Confirm perfect run lands ≥ 15000 (tunable if it doesn't)
- [ ] Confirm no clipping into stats line at 480×270