### PR TITLE
fix(#57): block defense placement on water tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Player-facing change log. The in-game overlay (Shift+C) parses this file at
 load time, splitting on `## ` version headings.
 
 ## v0.1.3 (in progress)
+- Fix: defenses can no longer be placed on water tiles (#57). The
+  placement validator was treating any non-asset tile as buildable
+  road, so the rivers around Manhattan accepted defenses.
 
 ## v0.1.2 — 2026-04-26
 - Fix: title screen reads the released version from CHANGELOG.md

--- a/src/game/map.js
+++ b/src/game/map.js
@@ -49,6 +49,7 @@ function inPark(x, y) {
 // Every playable tile is one of these types. Defenses render on top of the
 // underlying asset; placement validity checks this function.
 export function getTileType(x, y) {
+  if (!isLand(x, y)) return 'water';
   if (BRIDGES.some(b => b.tile.x === x && b.tile.y === y)) return 'bridge';
   if (APARTMENTS.some(a => a.tile.x === x && a.tile.y === y)) return 'apartment';
   if (SKYSCRAPERS.some(s => s.tile.x === x && s.tile.y === y)) return 'skyscraper';
@@ -63,8 +64,7 @@ export function getTileType(x, y) {
 
 export function isBuildableType(type) {
   // Defenses may sit on top of roads/apartments/skyscrapers.
-  // Blocked: bridge (supply line), park (green space), structure (anchor),
-  // water (outside grid — caller filters).
+  // Blocked: bridge (supply line), park (green space), structure (anchor), water.
   return type === 'road' || type === 'apartment' || type === 'skyscraper';
 }
 


### PR DESCRIPTION
Closes #57.

## Summary
- `getTileType` returned `'road'` as the default for any tile that wasn't a known asset, so water tiles fell through to a buildable type. Now it consults `isLand` first and returns `'water'` — which `isBuildableType` already rejects.
- CHANGELOG entry under v0.1.3.

## Test plan
- [ ] `npx serve`, open the game, select any defense
- [ ] Hover the rivers / map edges → ghost shows the red X overlay
- [ ] Click on water → no defense placed, no inventory deducted
- [ ] Land placement still works (road / apartment / skyscraper tiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)